### PR TITLE
Update fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ audio = []
 # Used to skip running certain tests on CI, since it's running in a headless environment.
 ci-headless = []
 
+[dependencies]
+num-traits = "0.2.15"
+
 [dependencies.once_cell]
 version = "1.7.2"
 optional = true

--- a/src/graphics/rect.rs
+++ b/src/graphics/rect.rs
@@ -1,5 +1,10 @@
+use num_traits::AsPrimitive;
+
 use crate::system::Vector2;
-use std::ops::{Add, Sub};
+use std::{
+    convert::TryInto,
+    ops::{Add, Sub},
+};
 
 use crate::ffi;
 
@@ -40,6 +45,43 @@ impl<T> Rect<T> {
             top: pos.y,
             width: size.x,
             height: size.y,
+        }
+    }
+
+    /// Lossless conversion into `Rect<U>`.
+    pub fn into_other<U>(self) -> Rect<U>
+    where
+        T: Into<U>,
+    {
+        Rect {
+            top: self.top.into(),
+            left: self.left.into(),
+            width: self.width.into(),
+            height: self.height.into(),
+        }
+    }
+    /// Fallible conversion into `Rect<U>`
+    pub fn try_into_other<U>(self) -> Result<Rect<U>, T::Error>
+    where
+        T: TryInto<U>,
+    {
+        Ok(Rect {
+            left: self.left.try_into()?,
+            top: self.top.try_into()?,
+            width: self.width.try_into()?,
+            height: self.height.try_into()?,
+        })
+    }
+    /// Lossy conversion into `Rect<U>`
+    pub fn as_other<U: 'static + Copy>(self) -> Rect<U>
+    where
+        T: AsPrimitive<U>,
+    {
+        Rect {
+            left: self.left.as_(),
+            top: self.top.as_(),
+            width: self.width.as_(),
+            height: self.height.as_(),
         }
     }
 }

--- a/src/system/vector2.rs
+++ b/src/system/vector2.rs
@@ -1,4 +1,8 @@
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use num_traits::AsPrimitive;
+use std::{
+    convert::TryInto,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+};
 
 /// Utility type for manipulating 2-dimensional vectors.
 ///
@@ -56,6 +60,36 @@ impl<T> Vector2<T> {
     /// Creates a new vector from its coordinates.
     pub const fn new(x: T, y: T) -> Self {
         Self { x, y }
+    }
+    /// Lossless conversion into `Vector2<U>`.
+    pub fn into_other<U>(self) -> Vector2<U>
+    where
+        T: Into<U>,
+    {
+        Vector2 {
+            x: self.x.into(),
+            y: self.y.into(),
+        }
+    }
+    /// Fallible conversion into `Vector2<U>`
+    pub fn try_into_other<U>(self) -> Result<Vector2<U>, T::Error>
+    where
+        T: TryInto<U>,
+    {
+        Ok(Vector2 {
+            x: self.x.try_into()?,
+            y: self.y.try_into()?,
+        })
+    }
+    /// Lossy conversion into `Vector2<U>`
+    pub fn as_other<U: 'static + Copy>(self) -> Vector2<U>
+    where
+        T: AsPrimitive<U>,
+    {
+        Vector2 {
+            x: self.x.as_(),
+            y: self.y.as_(),
+        }
     }
 }
 

--- a/src/system/vector3.rs
+++ b/src/system/vector3.rs
@@ -1,4 +1,9 @@
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::{
+    convert::TryInto,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
+};
+
+use num_traits::AsPrimitive;
 
 /// Utility type for manipulating 3-dimensional vectors.
 ///
@@ -52,6 +57,39 @@ impl<T> Vector3<T> {
     /// Create a new `Vector3` with the given values.
     pub const fn new(x: T, y: T, z: T) -> Self {
         Self { x, y, z }
+    }
+    /// Lossless conversion into `Vector3<U>`.
+    pub fn into_other<U>(self) -> Vector3<U>
+    where
+        T: Into<U>,
+    {
+        Vector3 {
+            x: self.x.into(),
+            y: self.y.into(),
+            z: self.z.into(),
+        }
+    }
+    /// Fallible conversion into `Vector3<U>`
+    pub fn try_into_other<U>(self) -> Result<Vector3<U>, T::Error>
+    where
+        T: TryInto<U>,
+    {
+        Ok(Vector3 {
+            x: self.x.try_into()?,
+            y: self.y.try_into()?,
+            z: self.z.try_into()?,
+        })
+    }
+    /// Lossy conversion into `Vector3<U>`
+    pub fn as_other<U: 'static + Copy>(self) -> Vector3<U>
+    where
+        T: AsPrimitive<U>,
+    {
+        Vector3 {
+            x: self.x.as_(),
+            y: self.y.as_(),
+            z: self.z.as_(),
+        }
     }
 }
 


### PR DESCRIPTION
… (#265)

Easy conversions between all primitive data types for vec2, vec3, and
Rect are now implemented with the `into_other`, `try_into_other`, and `as_other` methods.