### PR TITLE
Implement function to fetch raw texture behind an rc_texture

### DIFF
--- a/src/graphics/rc_texture.rs
+++ b/src/graphics/rc_texture.rs
@@ -127,6 +127,18 @@ impl RcTexture {
         self.texture.borrow_mut().create(width, height)
     }
 
+    /// Get the source texture of an [`RcTexture`]
+    ///
+    /// It let's you temporarily borrow the [`Texture`] being held by an [`RcTexture`].
+    /// This may be useful for many things, for example, using vertex arrays with
+    /// [`RcTexture`]. This allows users to use [`RcTexture`] with vertex arrays.
+    ///
+    /// Returns a [`Texture`]
+    #[must_use]
+    pub fn raw_texture(&self) -> &Texture {
+        unsafe { &*self.texture.as_ptr() }
+    }
+
     /// Load texture from memory
     ///
     /// The `area` argument can be used to load only a sub-rectangle of the whole image.


### PR DESCRIPTION
This can be useful for many things like allowing the user the use Sprites, Shapes, VertexArrays, etc... with the RcTexture. I found this limitation out recently and realized I kind of needed this function to continue working. I don't see and negative side effects because it is using a borrow, so you can't really use that underlying raw texture as long as the RcTexture is alive.